### PR TITLE
Use GET for short link expansion in travel update

### DIFF
--- a/main.py
+++ b/main.py
@@ -3024,9 +3024,9 @@ class MainWindow(QMainWindow):
             if not raw or "/dir/" not in raw:
                 continue
 
-            # expand short links
+            # expand short links via GET to ensure redirects are followed
             long_url = raw
-            if raw.startswith("https://maps.app.goo.gl/"):
+            if "maps.app.goo.gl" in raw:
                 long_url = expand_short_link(raw)
 
             p = urlparse(long_url)


### PR DESCRIPTION
## Summary
- always expand short `maps.app.goo.gl` URLs using `expand_short_link`

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_683c3a27d6c8832f8fcc2f2c3db55972