### PR TITLE
Skip non Google Maps dir links

### DIFF
--- a/main.py
+++ b/main.py
@@ -3029,6 +3029,10 @@ class MainWindow(QMainWindow):
             if "maps.app.goo.gl" in raw:
                 long_url = expand_short_link(raw)
 
+            if "/maps/dir/" not in long_url:
+                # Not a directions link—skip this event
+                continue
+
             p = urlparse(long_url)
             qs = parse_qs(p.query)
             origin = qs.get("origin", [None])[0]


### PR DESCRIPTION
## Summary
- skip events if `long_url` does not contain `/maps/dir/`

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_683c3af4d9b8832fb94f87ef2056bc71